### PR TITLE
Managing 32-bit unsigned long return values

### DIFF
--- a/src/Oversampling.cpp
+++ b/src/Oversampling.cpp
@@ -17,7 +17,7 @@ Oversampling::Oversampling(int adcbytes, int samplebytes, int Averaging)
   _Averaging = Averaging;
 }
 
-int Oversampling::read(int pin)
+unsigned long Oversampling::read(int pin)
 {
   int SampleCount = _samplebytes - _adcbytes;
   SampleCount = constrain(SampleCount, 1, 8);


### PR DESCRIPTION
Thanks for this library.

I would suggest returning an unsigned long (0 to 4,294,967,295) rather than an int (-32,768 to 32,767).